### PR TITLE
🎨 Updated due to database encryption

### DIFF
--- a/src/components/TerminalManager/commands/login.command.ts
+++ b/src/components/TerminalManager/commands/login.command.ts
@@ -33,7 +33,7 @@ export const loginCommand: ICommand = {
 
       // 3. Send solved challenge to server
       await store.dispatch("finishAssertion", {
-        username: email,
+        email,
         assertionResponse,
       });
 

--- a/src/components/TerminalManager/commands/register.command.ts
+++ b/src/components/TerminalManager/commands/register.command.ts
@@ -32,7 +32,7 @@ export const registerCommand: ICommand = {
     try {
       // 1. Get options from server
       const attestationOptions: any = await store.dispatch("startAttestation", {
-        username: email,
+        email,
         token,
       });
 
@@ -41,7 +41,7 @@ export const registerCommand: ICommand = {
 
       // 3. Send reponse to server
       await store.dispatch("finishAttestation", {
-        username: email,
+        email,
         token,
         attestationResponse,
       });

--- a/src/components/TerminalManager/index.ts
+++ b/src/components/TerminalManager/index.ts
@@ -191,7 +191,7 @@ export class TerminalManager {
       } else {
         this.writeError(`${keyword}: command not found`);
         this.printPrompt();
-      }
+      } 
     } else {
       this.printPrompt();
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -85,11 +85,11 @@ export default createStore({
       });
     },
 
-    startAssertion({ commit }, username) {
+    startAssertion({ commit }, email) {
       commit("SET_AUTH");
       return new Promise<void>((resolve, reject) => {
         api
-          .get("/authentication/login", { params: { username } })
+          .get("/authentication/login", { params: { email } })
           .then(({ data: apiResponse }) => {
             if (apiResponse.status === "success") {
               commit("SET_AUTH", null);


### PR DESCRIPTION
The username for `login.commands.ts` and `register.commands.ts` was renamed to the email. This served to standardise and simplify the application. The user should log on to the website via email and use this as authentication. There is no classic user name, so this designation could be eliminated. 🍻