### PR TITLE
🚸 Add multi-line command support

### DIFF
--- a/src/components/TerminalManager/index.ts
+++ b/src/components/TerminalManager/index.ts
@@ -361,8 +361,10 @@ export class TerminalManager {
         }
         break;
       default: {
-        // Remove beginning or trailing whitespace
-        text = text.trim()
+        if (text.length > 1){
+          // Remove beginning or trailing whitespace
+          text = text.trim()
+        }
         // Check for multi-line commands
         if (/\r\n|\r|\n/.test(text)) {
           const [firstLine, /**newlineChar*/, otherLines] = text.split(/(\r\n|\r|\n)([\s\S]*)/);


### PR DESCRIPTION
This PR adds terminal support for multi-line commands (e.g. pasting multiple commands at once from an editor).

Remarks:
- The last line will never be executed automatically, even if there are one or more newlines at the end. This is by intent because most of the time you don't want this behavior 😊 
- This PR is independent from #9 
